### PR TITLE
Add Adafruit-Blinka to requirements for PyPI compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+Adafruit-Blinka
 adafruit-circuitpython-register
 adafruit-circuitpython-busdevice


### PR DESCRIPTION
Fix for issue listed in https://github.com/adafruit/circuitpython/issues/1246
> For pypi compatibility, missing Adafruit-Blinka in requirements.txt - 22