### PR TITLE
Remove verification check

### DIFF
--- a/adafruit_ds3231.py
+++ b/adafruit_ds3231.py
@@ -97,12 +97,6 @@ class DS3231:
     def __init__(self, i2c):
         self.i2c_device = I2CDevice(i2c, 0x68)
 
-        # Try and verify this is the RTC we expect by checking change in secs
-        check = self.datetime_register.tm_sec
-        time.sleep(1.1)
-        if self.datetime_register.tm_sec == check:
-            raise ValueError("Unable to find DS3231 at i2c address 0x68.")
-
     @property
     def datetime(self):
         """Gets the current date and time or sets the current date and time

--- a/adafruit_ds3231.py
+++ b/adafruit_ds3231.py
@@ -54,6 +54,7 @@ Implementation Notes
 #. Datasheet: https://datasheets.maximintegrated.com/en/ds/DS3231.pdf
 
 """
+import time
 from adafruit_bus_device.i2c_device import I2CDevice
 from adafruit_register import i2c_bit
 from adafruit_register import i2c_bcd_alarm
@@ -96,14 +97,10 @@ class DS3231:
     def __init__(self, i2c):
         self.i2c_device = I2CDevice(i2c, 0x68)
 
-        # Try and verify this is the RTC we expect by checking the rate select
-        # control bits which are 1 on reset and shouldn't ever be changed.
-        buf = bytearray(2)
-        buf[0] = 0x0e
-        with self.i2c_device as i2c_device:
-            i2c_device.write_then_readinto(buf, buf, out_end=1, in_start=1)
-
-        if (buf[1] & 0b00011000) != 0b00011000:
+        # Try and verify this is the RTC we expect by checking change in secs
+        check = self.datetime_register.tm_sec
+        time.sleep(1.1)
+        if self.datetime_register.tm_sec == check:
             raise ValueError("Unable to find DS3231 at i2c address 0x68.")
 
     @property

--- a/adafruit_ds3231.py
+++ b/adafruit_ds3231.py
@@ -54,7 +54,6 @@ Implementation Notes
 #. Datasheet: https://datasheets.maximintegrated.com/en/ds/DS3231.pdf
 
 """
-import time
 from adafruit_bus_device.i2c_device import I2CDevice
 from adafruit_register import i2c_bit
 from adafruit_register import i2c_bcd_alarm


### PR DESCRIPTION
Possible fix for #15 

Uses approach proposed by @gritnix in issue thread which checks for elapsed time. This slows down the constructor, but avoids relying on a register value that may not be as expected due to regular use.