### PR TITLE
DS3231: Add calibration, temperature, and force_conversion

### DIFF
--- a/adafruit_ds3231.py
+++ b/adafruit_ds3231.py
@@ -124,25 +124,26 @@ class DS3231:
         only every 64 seconds, or when a conversion is forced."""
         return self._temperature / 4
 
-    def force_conversion(self):
+    def force_temperature_conversion(self):
         """Forces a conversion and returns the new temperature"""
         while self._busy:
-            pass
+            pass  # Wait for any normal in-progress conversion to complete
         self._conv = True
-        while self._busy:
-            pass
+        while self._conv:
+            pass  # Wait for manual conversion request to complete
         return self.temperature
 
     @property
     def calibration(self):
-        """Calibration values range from -128 to 127; each step is
-        approximately 0.1ppm, and positive values decrease the frequency
-        (increase the period).  When set, a temperature conversion is forced so
-        the result of calibration can be seen directly at the 32kHz pin after
-        the next temperature conversion."""
+        """Calibrate the frequency of the crystal oscillator by adding or
+        removing capacitance.  The datasheet calls this the Aging Offset.
+        Calibration values range from -128 to 127; each step is approximately
+        0.1ppm, and positive values decrease the frequency (increase the
+        period).  When set, a temperature conversion is forced so the result of
+        calibration can be seen directly at the 32kHz pin immediately"""
         return self._calibration
 
     @calibration.setter
     def calibration(self, value):
         self._calibration = value
-        self.force_conversion()
+        self.force_temperature_conversion()

--- a/adafruit_ds3231.py
+++ b/adafruit_ds3231.py
@@ -120,7 +120,8 @@ class DS3231:
 
     @property
     def temperature(self):
-        """Returns the last temperature measurement.  Temperature is updated only every 64 seconds, or when a conversion is forced."""
+        """Returns the last temperature measurement.  Temperature is updated
+        only every 64 seconds, or when a conversion is forced."""
         return self._temperature / 4
 
     def force_conversion(self):
@@ -134,7 +135,11 @@ class DS3231:
 
     @property
     def calibration(self):
-        """Calibration values range from -128 to 127; each step is approximately 0.1ppm, and positive values decrease the frequency (increase the period).  When set, a temperature conversion is forced so the result of calibration can be seen directly at the 32kHz pin after the next temperature conversion."""
+        """Calibration values range from -128 to 127; each step is
+        approximately 0.1ppm, and positive values decrease the frequency
+        (increase the period).  When set, a temperature conversion is forced so
+        the result of calibration can be seen directly at the 32kHz pin after
+        the next temperature conversion."""
         return self._calibration
 
     @calibration.setter


### PR DESCRIPTION
This device has a temperature sensor with 0.25°C precision, and an "aging offset" which can be used to calibrate the crystal
frequency for increased timekeeping accuracy.

Expose these as properties.

This requires https://github.com/adafruit/Adafruit_CircuitPython_Register/pull/39 as the temperature and calibration registers hold signed values.

With these changes, I was able to use a precision frequency meter to "tune" the RTC so that it would have less than .01 seconds per day of error at 27°C, by assigning the best value to the calibration register.