### PR TITLE
correct register width when retrieving calibration register (fixes #30)

### DIFF
--- a/adafruit_ds3231.py
+++ b/adafruit_ds3231.py
@@ -94,7 +94,7 @@ class DS3231:
     alarm2_status = i2c_bit.RWBit(0x0F, 1)
     """True if alarm2 is alarming. Set to False to reset."""
 
-    _calibration = i2c_bits.RWBits(8, 0x10, 0, 8, signed=True)
+    _calibration = i2c_bits.RWBits(8, 0x10, 0, 1, signed=True)
 
     _temperature = i2c_bits.RWBits(
         10, 0x11, 6, register_width=2, lsb_first=False, signed=True


### PR DESCRIPTION
Register width parameter of call to i2c_bits.RWBits specifies the width of the register in bytes. However, in the following call, register width is passed as 8.

`_calibration = i2c_bits.RWBits(8, 0x10, 0, 8, signed=True)`

This results in an 8 byte register (64 bit). This fails on feather m0 adalogger because maximum integer value for a python int on this platform is (2^30)-1

The register should only be 1 byte, the 8 is probably a typo because the other arguments passed are in bits.

Fixes: #30 