### PR TITLE
Update example to have Monday at index 0

### DIFF
--- a/examples/ds3231_simpletest.py
+++ b/examples/ds3231_simpletest.py
@@ -14,7 +14,7 @@ i2c = board.I2C()  # uses board.SCL and board.SDA
 rtc = adafruit_ds3231.DS3231(i2c)
 
 # Lookup table for names of days (nicer printing).
-days = ("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
+days = ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
 
 
 # pylint: disable-msg=using-constant-test


### PR DESCRIPTION
Matches correct behavior of weekday number, with Monday as 0

Didn't change any of the driver code, and looking through it, it seems as if it's functioning as intended.  Still, hardware on the way to fully test if necessary.