### PR TITLE
update docs badge url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Introduction
 =============
 
-.. image:: https://readthedocs.org/projects/adafruit-micropython-ds3231/badge/?version=latest
+.. image:: https://readthedocs.org/projects/adafruit-circuitpython-ds3231-x/badge/?version=latest
     :target: https://docs.circuitpython.org/projects/ds3231/en/latest/
     :alt: Documentation Status
 


### PR DESCRIPTION
the slug for this project is `adafruit-circuitpython-ds3231-x`   https://app.readthedocs.org/projects/adafruit-circuitpython-ds3231-x/builds/

This being mismatched also causes issues for adabot, first noticed here: https://github.com/adafruit/adabot/pull/394